### PR TITLE
CI: Rebuild packages on merge to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: "Build"
 on:
+  push:
+    branches: [ master ]
   pull_request:
 jobs:
   build:


### PR DESCRIPTION
Make it easier to build release binaries after merging PRs to master.