### PR TITLE
CI: print sha256 hashes of artifacts after building packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
           go-version: '1.17.9'
       - run: make test
       - run: make package
+      - run: sha256sum node_exporter node_exporter*.tar.gz
       - uses: actions/upload-artifact@v3
         with:
           name: package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: '1.17.9'
       - run: make test
       - run: make package
-      - run: sha256sum node_exporter node_exporter*.tar.gz
+      - run: shasum -a 256 node_exporter node_exporter*.tar.gz
       - uses: actions/upload-artifact@v3
         with:
           name: package


### PR DESCRIPTION
To help with reproducing locally and verifying builds match.