### PR TITLE
ignore malformed metrics with } before {

### DIFF
--- a/collector/gateway.go
+++ b/collector/gateway.go
@@ -218,6 +218,9 @@ func (c *GatewayCollector) parsePostMetrics(metrics string) {
 			if !strings.Contains(l, "}") {
 				continue
 			}
+			if strings.Index(l, "}") < strings.Index(l, "{") {
+				continue
+			}
 			labelsBlock = l[strings.Index(l, "{")+1 : strings.Index(l, "}")]
 		} else {
 			metricName = l[0:strings.Index(l, " ")]

--- a/collector/gateway_test.go
+++ b/collector/gateway_test.go
@@ -1,0 +1,17 @@
+package collector
+
+import (
+	"testing"
+)
+
+func TestGatewayCollectorBadMetrics(t *testing.T) {
+	g := newGatewayCollector()
+	g.parsePostMetrics(`
+# HELP badm Metric with a bad name.
+# TYPE badm counter
+badm}{pid="31579",host="ip-172-31-44-208"} 1466740
+`)
+	if len(g.counters) > 0 || len(g.gauges) > 0 || len(g.labels) > 0 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Fix parse error for malformed prometheus lines.